### PR TITLE
feat: Add AWS Glue + Athena infrastructure for real estate data analysis

### DIFF
--- a/aws-infrastructure/README.md
+++ b/aws-infrastructure/README.md
@@ -1,0 +1,295 @@
+# AWS Infrastructure for Real Estate Data Analysis
+
+This directory contains AWS CloudFormation templates and resources for setting up a Glue + Athena analytics infrastructure for the real estate data stored in S3.
+
+## Overview
+
+The infrastructure provides:
+- AWS Glue Database and Crawler for automatic schema discovery
+- Explicit table definitions for both Parquet and CSV formats
+- Pre-configured Athena workgroup for query execution
+- Sample SQL queries for common analysis patterns
+- Support for partitioned data by date
+
+## Architecture
+
+```
+S3 Bucket (real-estate-data)
+    ├── cleaned/
+    │   └── tokyo/
+    │       ├── year=2024/month=01/day=01/
+    │       │   └── *.parquet
+    │       └── year=2024/month=01/day=02/
+    │           └── *.parquet
+    └── athena-results/
+        └── (query results)
+                ↓
+        Glue Crawler
+                ↓
+        Glue Database
+                ↓
+        Athena Queries
+                ↓
+    Analysis Results
+```
+
+## Files
+
+### CloudFormation Templates
+
+1. **glue-athena-stack.yaml** - Main infrastructure stack
+   - Glue Database
+   - Glue Crawler with IAM role
+   - Athena Workgroup
+   - Pre-defined Named Queries
+
+2. **glue-table-schema.yaml** - Explicit table definitions
+   - Parquet table schema
+   - CSV table schema (alternative)
+   - Field mapping documentation
+
+### Athena Query Examples
+
+Located in `athena-queries/`:
+- `01_average_rent_by_ward.sql` - Average rent statistics by Tokyo ward
+- `02_station_distance_analysis.sql` - Analysis by walking distance to station
+- `03_building_age_distribution.sql` - Property distribution by building age
+- `04_floor_plan_analysis.sql` - Analysis by floor plan type
+- `05_price_per_sqm_by_location.sql` - Rent efficiency by location
+- `06_comprehensive_property_analysis.sql` - Multi-dimensional analysis
+- `07_time_series_analysis.sql` - Trends over time
+- `08_best_value_properties.sql` - Find best value properties
+
+## Deployment Guide
+
+### Prerequisites
+
+1. AWS CLI configured with appropriate credentials
+2. S3 bucket with real estate data
+3. Appropriate IAM permissions for CloudFormation
+
+### Step 1: Deploy Main Infrastructure
+
+```bash
+aws cloudformation create-stack \
+  --stack-name real-estate-glue-athena \
+  --template-body file://glue-athena-stack.yaml \
+  --parameters \
+    ParameterKey=S3BucketName,ParameterValue=your-bucket-name \
+    ParameterKey=DataPrefix,ParameterValue=cleaned/tokyo/ \
+  --capabilities CAPABILITY_NAMED_IAM
+```
+
+### Step 2: Deploy Table Schema (Optional)
+
+If you want explicit table definitions instead of relying on the crawler:
+
+```bash
+aws cloudformation create-stack \
+  --stack-name real-estate-table-schema \
+  --template-body file://glue-table-schema.yaml \
+  --parameters \
+    ParameterKey=S3BucketName,ParameterValue=your-bucket-name \
+    ParameterKey=GlueDatabaseName,ParameterValue=real_estate_db
+```
+
+### Step 3: Run the Crawler
+
+After deployment, run the crawler to discover your data:
+
+```bash
+aws glue start-crawler --name real-estate-crawler
+```
+
+Check crawler status:
+
+```bash
+aws glue get-crawler --name real-estate-crawler
+```
+
+### Step 4: Verify Tables
+
+List tables in the database:
+
+```bash
+aws glue get-tables --database-name real_estate_db
+```
+
+## Using Athena
+
+### Via AWS Console
+
+1. Open Athena Console
+2. Select workgroup: `real-estate-analysis`
+3. Select database: `real_estate_db`
+4. Run queries from the `athena-queries/` directory
+
+### Via AWS CLI
+
+```bash
+# Start query execution
+aws athena start-query-execution \
+  --query-string "SELECT COUNT(*) FROM real_estate_db.tokyo_properties" \
+  --work-group real-estate-analysis \
+  --query-execution-context Database=real_estate_db
+
+# Get query results
+aws athena get-query-results --query-execution-id <execution-id>
+```
+
+### Via Python (boto3)
+
+```python
+import boto3
+import time
+
+athena = boto3.client('athena')
+
+# Execute query
+response = athena.start_query_execution(
+    QueryString='SELECT city, AVG(rent) as avg_rent FROM real_estate_db.tokyo_properties GROUP BY city',
+    QueryExecutionContext={'Database': 'real_estate_db'},
+    WorkGroup='real-estate-analysis'
+)
+
+query_execution_id = response['QueryExecutionId']
+
+# Wait for completion
+while True:
+    result = athena.get_query_execution(QueryExecutionId=query_execution_id)
+    status = result['QueryExecution']['Status']['State']
+    
+    if status in ['SUCCEEDED', 'FAILED', 'CANCELLED']:
+        break
+    time.sleep(1)
+
+# Get results
+if status == 'SUCCEEDED':
+    results = athena.get_query_results(QueryExecutionId=query_execution_id)
+    # Process results...
+```
+
+## Field Mapping Reference
+
+The table schema maps the issue requirements to actual field names:
+
+| Requirement | Actual Field | Type |
+|-------------|--------------|------|
+| price | rent | int |
+| area | area | float |
+| layout | floor_plan | string |
+| year_built | construction_year | int |
+| walk_time_to_station | station_distance | int |
+| latitude | latitude | float |
+| longitude | longitude | float |
+| date | scraped_at | timestamp |
+| address | address | string |
+
+## Cost Optimization
+
+1. **Data Format**: Use Parquet format with Snappy compression
+2. **Partitioning**: Data is partitioned by year/month/day
+3. **Query Optimization**: 
+   - Use partition filters: `WHERE year='2024' AND month='01'`
+   - Limit data scanned with column selection
+   - Use LIMIT for exploratory queries
+
+## Integration with Other Services
+
+### QuickSight
+
+1. Create a QuickSight data source pointing to Athena
+2. Use the `real_estate_db` database
+3. Create visualizations based on the queries
+
+### SageMaker
+
+```python
+# Example: Load data from Athena into SageMaker
+import awswrangler as wr
+
+df = wr.athena.read_sql_query(
+    sql="SELECT * FROM real_estate_db.tokyo_properties WHERE year='2024'",
+    database="real_estate_db",
+    workgroup="real-estate-analysis"
+)
+```
+
+### Redshift Spectrum
+
+```sql
+-- Create external schema in Redshift
+CREATE EXTERNAL SCHEMA real_estate_spectrum
+FROM DATA CATALOG
+DATABASE 'real_estate_db'
+IAM_ROLE 'arn:aws:iam::123456789012:role/RedshiftSpectrumRole';
+
+-- Query from Redshift
+SELECT * FROM real_estate_spectrum.tokyo_properties LIMIT 10;
+```
+
+## Maintenance
+
+### Update Crawler Schedule
+
+```bash
+aws glue update-crawler \
+  --name real-estate-crawler \
+  --schedule "cron(0 2 * * ? *)"  # Daily at 2 AM UTC
+```
+
+### Monitor Query Costs
+
+```bash
+# Get workgroup metrics
+aws cloudwatch get-metric-statistics \
+  --namespace AWS/Athena \
+  --metric-name DataScannedInBytes \
+  --dimensions Name=WorkGroup,Value=real-estate-analysis \
+  --start-time 2024-01-01T00:00:00Z \
+  --end-time 2024-01-31T23:59:59Z \
+  --period 86400 \
+  --statistics Sum
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Crawler finds no tables**
+   - Check S3 bucket permissions
+   - Verify data exists at the specified prefix
+   - Check crawler logs in CloudWatch
+
+2. **Query returns no results**
+   - Verify table schema matches actual data
+   - Check partition filters
+   - Ensure data types are correct
+
+3. **Permission denied errors**
+   - Check IAM role has S3 access
+   - Verify Athena workgroup permissions
+   - Ensure query result location is accessible
+
+### Debug Commands
+
+```bash
+# Check crawler logs
+aws logs tail /aws-glue/crawlers --follow
+
+# Describe table schema
+aws glue get-table \
+  --database-name real_estate_db \
+  --name tokyo_properties
+
+# Test S3 access
+aws s3 ls s3://your-bucket-name/cleaned/tokyo/ --recursive
+```
+
+## Next Steps
+
+1. Set up automated data quality checks
+2. Create CloudWatch dashboards for monitoring
+3. Implement cost allocation tags
+4. Set up query result caching
+5. Create materialized views for common queries

--- a/aws-infrastructure/athena-queries/01_average_rent_by_ward.sql
+++ b/aws-infrastructure/athena-queries/01_average_rent_by_ward.sql
@@ -1,0 +1,18 @@
+-- Average Rent by Ward
+-- Calculate average rent statistics by Tokyo ward
+
+SELECT 
+    city as ward,
+    property_type,
+    COUNT(*) as property_count,
+    AVG(rent) as avg_rent,
+    MIN(rent) as min_rent,
+    MAX(rent) as max_rent,
+    APPROX_PERCENTILE(rent, 0.5) as median_rent,
+    STDDEV(rent) as rent_stddev
+FROM real_estate_db.tokyo_properties
+WHERE rent > 0
+    AND rent < 1000000  -- Filter out unrealistic values
+GROUP BY city, property_type
+HAVING COUNT(*) >= 5  -- Only show wards with at least 5 properties
+ORDER BY avg_rent DESC;

--- a/aws-infrastructure/athena-queries/02_station_distance_analysis.sql
+++ b/aws-infrastructure/athena-queries/02_station_distance_analysis.sql
@@ -1,0 +1,38 @@
+-- Property Analysis by Station Distance
+-- Analyze how walking distance to station affects rent and property characteristics
+
+SELECT 
+    CASE 
+        WHEN station_distance <= 5 THEN '0-5 minutes'
+        WHEN station_distance <= 10 THEN '6-10 minutes'
+        WHEN station_distance <= 15 THEN '11-15 minutes'
+        WHEN station_distance <= 20 THEN '16-20 minutes'
+        ELSE '20+ minutes'
+    END as distance_range,
+    COUNT(*) as property_count,
+    AVG(area) as avg_area_sqm,
+    AVG(rent) as avg_rent,
+    AVG(rent / NULLIF(area, 0)) as avg_rent_per_sqm,
+    APPROX_PERCENTILE(rent, 0.5) as median_rent
+FROM real_estate_db.tokyo_properties
+WHERE station_distance IS NOT NULL
+    AND station_distance >= 0
+    AND station_distance <= 60  -- Filter out unrealistic values
+    AND area > 0
+    AND rent > 0
+GROUP BY 
+    CASE 
+        WHEN station_distance <= 5 THEN '0-5 minutes'
+        WHEN station_distance <= 10 THEN '6-10 minutes'
+        WHEN station_distance <= 15 THEN '11-15 minutes'
+        WHEN station_distance <= 20 THEN '16-20 minutes'
+        ELSE '20+ minutes'
+    END
+ORDER BY 
+    CASE distance_range
+        WHEN '0-5 minutes' THEN 1
+        WHEN '6-10 minutes' THEN 2
+        WHEN '11-15 minutes' THEN 3
+        WHEN '16-20 minutes' THEN 4
+        ELSE 5
+    END;

--- a/aws-infrastructure/athena-queries/03_building_age_distribution.sql
+++ b/aws-infrastructure/athena-queries/03_building_age_distribution.sql
@@ -1,0 +1,58 @@
+-- Building Age Distribution
+-- Analyze property distribution and pricing by building age
+
+WITH current_year AS (
+    SELECT YEAR(CURRENT_DATE) as year
+),
+age_calculated AS (
+    SELECT 
+        property_id,
+        rent,
+        area,
+        property_type,
+        city,
+        -- Calculate building age from construction year if not provided
+        COALESCE(
+            building_age,
+            (SELECT year FROM current_year) - construction_year
+        ) as calculated_age
+    FROM real_estate_db.tokyo_properties
+    WHERE rent > 0 
+        AND area > 0
+        AND (building_age IS NOT NULL OR construction_year IS NOT NULL)
+)
+SELECT 
+    CASE 
+        WHEN calculated_age <= 5 THEN '0-5 years (築浅)'
+        WHEN calculated_age <= 10 THEN '6-10 years'
+        WHEN calculated_age <= 15 THEN '11-15 years'
+        WHEN calculated_age <= 20 THEN '16-20 years'
+        WHEN calculated_age <= 30 THEN '21-30 years'
+        ELSE '30+ years (築古)'
+    END as age_range,
+    COUNT(*) as property_count,
+    AVG(rent) as avg_rent,
+    AVG(area) as avg_area_sqm,
+    AVG(rent / area) as avg_rent_per_sqm,
+    APPROX_PERCENTILE(rent, 0.5) as median_rent
+FROM age_calculated
+WHERE calculated_age >= 0 
+    AND calculated_age <= 100  -- Filter out unrealistic values
+GROUP BY 
+    CASE 
+        WHEN calculated_age <= 5 THEN '0-5 years (築浅)'
+        WHEN calculated_age <= 10 THEN '6-10 years'
+        WHEN calculated_age <= 15 THEN '11-15 years'
+        WHEN calculated_age <= 20 THEN '16-20 years'
+        WHEN calculated_age <= 30 THEN '21-30 years'
+        ELSE '30+ years (築古)'
+    END
+ORDER BY 
+    CASE age_range
+        WHEN '0-5 years (築浅)' THEN 1
+        WHEN '6-10 years' THEN 2
+        WHEN '11-15 years' THEN 3
+        WHEN '16-20 years' THEN 4
+        WHEN '21-30 years' THEN 5
+        ELSE 6
+    END;

--- a/aws-infrastructure/athena-queries/04_floor_plan_analysis.sql
+++ b/aws-infrastructure/athena-queries/04_floor_plan_analysis.sql
@@ -1,0 +1,22 @@
+-- Floor Plan Analysis
+-- Analyze property distribution and pricing by floor plan type
+
+SELECT 
+    floor_plan,
+    property_type,
+    COUNT(*) as property_count,
+    AVG(rent) as avg_rent,
+    AVG(area) as avg_area_sqm,
+    MIN(rent) as min_rent,
+    MAX(rent) as max_rent,
+    APPROX_PERCENTILE(rent, 0.5) as median_rent,
+    AVG(rent / NULLIF(area, 0)) as avg_rent_per_sqm
+FROM real_estate_db.tokyo_properties
+WHERE floor_plan IS NOT NULL
+    AND rent > 0
+    AND area > 0
+    AND rent < 1000000  -- Filter out unrealistic values
+GROUP BY floor_plan, property_type
+HAVING COUNT(*) >= 3  -- Only show floor plans with at least 3 properties
+ORDER BY property_count DESC, avg_rent DESC
+LIMIT 30;

--- a/aws-infrastructure/athena-queries/05_price_per_sqm_by_location.sql
+++ b/aws-infrastructure/athena-queries/05_price_per_sqm_by_location.sql
@@ -1,0 +1,31 @@
+-- Price per Square Meter by Location
+-- Calculate rent per square meter statistics by ward to understand pricing efficiency
+
+WITH price_per_sqm AS (
+    SELECT 
+        city as ward,
+        property_type,
+        property_id,
+        rent,
+        area,
+        rent / area as rent_per_sqm
+    FROM real_estate_db.tokyo_properties
+    WHERE rent > 0 
+        AND area > 10  -- Filter out unrealistically small areas
+        AND rent < 1000000  -- Filter out unrealistic rents
+)
+SELECT 
+    ward,
+    property_type,
+    COUNT(*) as property_count,
+    ROUND(AVG(rent_per_sqm), 0) as avg_rent_per_sqm,
+    ROUND(MIN(rent_per_sqm), 0) as min_rent_per_sqm,
+    ROUND(MAX(rent_per_sqm), 0) as max_rent_per_sqm,
+    ROUND(APPROX_PERCENTILE(rent_per_sqm, 0.25), 0) as q1_rent_per_sqm,
+    ROUND(APPROX_PERCENTILE(rent_per_sqm, 0.5), 0) as median_rent_per_sqm,
+    ROUND(APPROX_PERCENTILE(rent_per_sqm, 0.75), 0) as q3_rent_per_sqm
+FROM price_per_sqm
+WHERE rent_per_sqm < 10000  -- Filter out unrealistic values
+GROUP BY ward, property_type
+HAVING COUNT(*) >= 10  -- Only show wards with sufficient data
+ORDER BY avg_rent_per_sqm DESC;

--- a/aws-infrastructure/athena-queries/06_comprehensive_property_analysis.sql
+++ b/aws-infrastructure/athena-queries/06_comprehensive_property_analysis.sql
@@ -1,0 +1,57 @@
+-- Comprehensive Property Analysis
+-- Multi-dimensional analysis combining location, size, age, and station distance
+
+WITH property_metrics AS (
+    SELECT 
+        city as ward,
+        property_type,
+        floor_plan,
+        -- Age grouping
+        CASE 
+            WHEN COALESCE(building_age, YEAR(CURRENT_DATE) - construction_year) <= 10 THEN 'New (≤10 years)'
+            WHEN COALESCE(building_age, YEAR(CURRENT_DATE) - construction_year) <= 20 THEN 'Medium (11-20 years)'
+            ELSE 'Old (>20 years)'
+        END as age_group,
+        -- Station distance grouping
+        CASE 
+            WHEN station_distance <= 10 THEN 'Near (≤10 min)'
+            ELSE 'Far (>10 min)'
+        END as station_proximity,
+        -- Area size grouping
+        CASE 
+            WHEN area <= 25 THEN 'Small (≤25㎡)'
+            WHEN area <= 40 THEN 'Medium (26-40㎡)'
+            ELSE 'Large (>40㎡)'
+        END as size_category,
+        rent,
+        area,
+        rent / area as rent_per_sqm
+    FROM real_estate_db.tokyo_properties
+    WHERE rent > 0 
+        AND area > 10
+        AND station_distance IS NOT NULL
+        AND (building_age IS NOT NULL OR construction_year IS NOT NULL)
+)
+SELECT 
+    ward,
+    property_type,
+    age_group,
+    station_proximity,
+    size_category,
+    COUNT(*) as property_count,
+    ROUND(AVG(rent), 0) as avg_rent,
+    ROUND(AVG(area), 1) as avg_area,
+    ROUND(AVG(rent_per_sqm), 0) as avg_rent_per_sqm,
+    ROUND(APPROX_PERCENTILE(rent, 0.5), 0) as median_rent
+FROM property_metrics
+GROUP BY 
+    ward,
+    property_type,
+    age_group,
+    station_proximity,
+    size_category
+HAVING COUNT(*) >= 3
+ORDER BY 
+    ward,
+    property_type,
+    avg_rent DESC;

--- a/aws-infrastructure/athena-queries/07_time_series_analysis.sql
+++ b/aws-infrastructure/athena-queries/07_time_series_analysis.sql
@@ -1,0 +1,39 @@
+-- Time Series Analysis
+-- Analyze property trends over time using scraped_at timestamp
+
+WITH monthly_stats AS (
+    SELECT 
+        DATE_TRUNC('month', scraped_at) as month,
+        city as ward,
+        property_type,
+        COUNT(*) as property_count,
+        AVG(rent) as avg_rent,
+        AVG(area) as avg_area,
+        AVG(rent / NULLIF(area, 0)) as avg_rent_per_sqm
+    FROM real_estate_db.tokyo_properties
+    WHERE rent > 0 
+        AND area > 0
+        AND scraped_at IS NOT NULL
+    GROUP BY 
+        DATE_TRUNC('month', scraped_at),
+        city,
+        property_type
+)
+SELECT 
+    month,
+    ward,
+    property_type,
+    property_count,
+    ROUND(avg_rent, 0) as avg_rent,
+    ROUND(avg_area, 1) as avg_area,
+    ROUND(avg_rent_per_sqm, 0) as avg_rent_per_sqm,
+    -- Calculate month-over-month changes
+    LAG(avg_rent) OVER (PARTITION BY ward, property_type ORDER BY month) as prev_month_rent,
+    ROUND(
+        100.0 * (avg_rent - LAG(avg_rent) OVER (PARTITION BY ward, property_type ORDER BY month)) / 
+        NULLIF(LAG(avg_rent) OVER (PARTITION BY ward, property_type ORDER BY month), 0), 
+        2
+    ) as rent_change_pct
+FROM monthly_stats
+WHERE property_count >= 5  -- Only include months with sufficient data
+ORDER BY month DESC, ward, property_type;

--- a/aws-infrastructure/athena-queries/08_best_value_properties.sql
+++ b/aws-infrastructure/athena-queries/08_best_value_properties.sql
@@ -1,0 +1,59 @@
+-- Best Value Properties Analysis
+-- Find properties that offer the best value based on multiple criteria
+
+WITH property_scores AS (
+    SELECT 
+        property_id,
+        title,
+        city as ward,
+        address,
+        property_type,
+        floor_plan,
+        rent,
+        area,
+        station_distance,
+        building_age,
+        rent / area as rent_per_sqm,
+        -- Calculate percentile ranks for each metric (lower is better for these metrics)
+        PERCENT_RANK() OVER (PARTITION BY city ORDER BY rent / area) as rent_efficiency_rank,
+        PERCENT_RANK() OVER (PARTITION BY city ORDER BY station_distance) as station_proximity_rank,
+        PERCENT_RANK() OVER (PARTITION BY city ORDER BY building_age) as newness_rank
+    FROM real_estate_db.tokyo_properties
+    WHERE rent > 0 
+        AND area > 15
+        AND station_distance IS NOT NULL
+        AND building_age IS NOT NULL
+        AND rent < 500000  -- Focus on reasonably priced properties
+),
+scored_properties AS (
+    SELECT 
+        *,
+        -- Calculate composite score (lower is better)
+        (rent_efficiency_rank * 0.5 + 
+         station_proximity_rank * 0.3 + 
+         newness_rank * 0.2) as value_score
+    FROM property_scores
+)
+SELECT 
+    ward,
+    property_id,
+    title,
+    address,
+    property_type,
+    floor_plan,
+    rent,
+    area,
+    ROUND(rent_per_sqm, 0) as rent_per_sqm,
+    station_distance as walk_to_station_min,
+    building_age as building_age_years,
+    ROUND(value_score * 100, 2) as value_score_pct,
+    CASE 
+        WHEN value_score <= 0.2 THEN 'Excellent Value'
+        WHEN value_score <= 0.4 THEN 'Good Value'
+        WHEN value_score <= 0.6 THEN 'Fair Value'
+        ELSE 'Below Average Value'
+    END as value_category
+FROM scored_properties
+WHERE value_score <= 0.4  -- Show only good and excellent value properties
+ORDER BY ward, value_score
+LIMIT 100;

--- a/aws-infrastructure/cleanup.sh
+++ b/aws-infrastructure/cleanup.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+# Real Estate Data Analysis Infrastructure Cleanup Script
+# This script removes the AWS Glue and Athena infrastructure
+
+set -e
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Default values
+STACK_NAME="real-estate-glue-athena"
+TABLE_STACK_NAME="real-estate-table-schema"
+REGION=${AWS_REGION:-"ap-northeast-1"}
+FORCE=false
+
+# Function to print colored output
+print_message() {
+    local color=$1
+    local message=$2
+    echo -e "${color}${message}${NC}"
+}
+
+# Function to check if stack exists
+stack_exists() {
+    aws cloudformation describe-stacks --stack-name $1 --region $REGION >/dev/null 2>&1
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --region)
+            REGION="$2"
+            shift 2
+            ;;
+        --force)
+            FORCE=true
+            shift
+            ;;
+        --help)
+            echo "Usage: $0 [options]"
+            echo ""
+            echo "Options:"
+            echo "  --region  AWS region (default: ap-northeast-1)"
+            echo "  --force   Skip confirmation prompt"
+            echo "  --help    Show this help message"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+print_message $YELLOW "🗑️  Real Estate Data Analysis Infrastructure Cleanup"
+echo "=================================================="
+echo "Region: $REGION"
+echo "Stacks to remove:"
+echo "  - $STACK_NAME"
+echo "  - $TABLE_STACK_NAME"
+echo "=================================================="
+echo ""
+
+# Confirmation prompt
+if [ "$FORCE" != true ]; then
+    print_message $YELLOW "⚠️  Warning: This will delete all infrastructure resources!"
+    read -p "Are you sure you want to continue? (yes/no): " confirm
+    if [ "$confirm" != "yes" ]; then
+        print_message $RED "Cleanup cancelled."
+        exit 0
+    fi
+fi
+
+# Check AWS CLI is installed
+if ! command -v aws &> /dev/null; then
+    print_message $RED "❌ AWS CLI is not installed. Please install it first."
+    exit 1
+fi
+
+# Check AWS credentials
+if ! aws sts get-caller-identity --region $REGION >/dev/null 2>&1; then
+    print_message $RED "❌ AWS credentials not configured or invalid."
+    exit 1
+fi
+
+# Function to delete stack
+delete_stack() {
+    local stack_name=$1
+    
+    if stack_exists $stack_name; then
+        print_message $YELLOW "🗑️  Deleting stack: $stack_name..."
+        
+        aws cloudformation delete-stack \
+            --stack-name $stack_name \
+            --region $REGION
+        
+        print_message $YELLOW "⏳ Waiting for stack deletion to complete..."
+        
+        aws cloudformation wait stack-delete-complete \
+            --stack-name $stack_name \
+            --region $REGION
+        
+        if [ $? -eq 0 ]; then
+            print_message $GREEN "✅ Stack $stack_name deleted successfully!"
+        else
+            print_message $RED "❌ Failed to delete stack $stack_name"
+            return 1
+        fi
+    else
+        print_message $YELLOW "Stack $stack_name does not exist, skipping..."
+    fi
+}
+
+# Delete table schema stack first (if it exists)
+delete_stack $TABLE_STACK_NAME
+
+# Delete main infrastructure stack
+delete_stack $STACK_NAME
+
+print_message $GREEN "✅ Cleanup completed successfully!"
+echo ""
+print_message $YELLOW "📝 Note: S3 data and Athena query results are NOT deleted."
+echo "To remove S3 data, use:"
+echo "  aws s3 rm s3://your-bucket-name/cleaned/ --recursive"
+echo "  aws s3 rm s3://your-bucket-name/athena-results/ --recursive"

--- a/aws-infrastructure/deploy.sh
+++ b/aws-infrastructure/deploy.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+
+# Real Estate Data Analysis Infrastructure Deployment Script
+# This script deploys the AWS Glue and Athena infrastructure for analyzing real estate data
+
+set -e
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Default values
+STACK_NAME="real-estate-glue-athena"
+TABLE_STACK_NAME="real-estate-table-schema"
+REGION=${AWS_REGION:-"ap-northeast-1"}
+S3_BUCKET=""
+DATA_PREFIX="cleaned/tokyo/"
+DEPLOY_TABLES=false
+
+# Function to print colored output
+print_message() {
+    local color=$1
+    local message=$2
+    echo -e "${color}${message}${NC}"
+}
+
+# Function to check if stack exists
+stack_exists() {
+    aws cloudformation describe-stacks --stack-name $1 --region $REGION >/dev/null 2>&1
+}
+
+# Function to wait for stack operation
+wait_for_stack() {
+    local stack_name=$1
+    local operation=$2
+    
+    print_message $YELLOW "⏳ Waiting for stack $operation to complete..."
+    
+    aws cloudformation wait stack-${operation}-complete \
+        --stack-name $stack_name \
+        --region $REGION
+    
+    if [ $? -eq 0 ]; then
+        print_message $GREEN "✅ Stack $operation completed successfully!"
+    else
+        print_message $RED "❌ Stack $operation failed!"
+        exit 1
+    fi
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --bucket)
+            S3_BUCKET="$2"
+            shift 2
+            ;;
+        --prefix)
+            DATA_PREFIX="$2"
+            shift 2
+            ;;
+        --region)
+            REGION="$2"
+            shift 2
+            ;;
+        --deploy-tables)
+            DEPLOY_TABLES=true
+            shift
+            ;;
+        --help)
+            echo "Usage: $0 --bucket <s3-bucket-name> [options]"
+            echo ""
+            echo "Options:"
+            echo "  --bucket         S3 bucket name (required)"
+            echo "  --prefix         S3 prefix for data (default: cleaned/tokyo/)"
+            echo "  --region         AWS region (default: ap-northeast-1)"
+            echo "  --deploy-tables  Also deploy explicit table definitions"
+            echo "  --help           Show this help message"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# Validate required parameters
+if [ -z "$S3_BUCKET" ]; then
+    print_message $RED "❌ Error: S3 bucket name is required!"
+    echo "Use: $0 --bucket <bucket-name>"
+    exit 1
+fi
+
+print_message $GREEN "🚀 Real Estate Data Analysis Infrastructure Deployment"
+echo "=================================================="
+echo "S3 Bucket: $S3_BUCKET"
+echo "Data Prefix: $DATA_PREFIX"
+echo "Region: $REGION"
+echo "Deploy Tables: $DEPLOY_TABLES"
+echo "=================================================="
+echo ""
+
+# Check AWS CLI is installed
+if ! command -v aws &> /dev/null; then
+    print_message $RED "❌ AWS CLI is not installed. Please install it first."
+    exit 1
+fi
+
+# Check AWS credentials
+if ! aws sts get-caller-identity --region $REGION >/dev/null 2>&1; then
+    print_message $RED "❌ AWS credentials not configured or invalid."
+    exit 1
+fi
+
+# Deploy main infrastructure stack
+print_message $YELLOW "📦 Deploying main infrastructure stack..."
+
+if stack_exists $STACK_NAME; then
+    print_message $YELLOW "Stack $STACK_NAME already exists. Updating..."
+    aws cloudformation update-stack \
+        --stack-name $STACK_NAME \
+        --template-body file://glue-athena-stack.yaml \
+        --parameters \
+            ParameterKey=S3BucketName,ParameterValue=$S3_BUCKET \
+            ParameterKey=DataPrefix,ParameterValue=$DATA_PREFIX \
+        --capabilities CAPABILITY_NAMED_IAM \
+        --region $REGION
+    
+    wait_for_stack $STACK_NAME "update"
+else
+    print_message $YELLOW "Creating new stack $STACK_NAME..."
+    aws cloudformation create-stack \
+        --stack-name $STACK_NAME \
+        --template-body file://glue-athena-stack.yaml \
+        --parameters \
+            ParameterKey=S3BucketName,ParameterValue=$S3_BUCKET \
+            ParameterKey=DataPrefix,ParameterValue=$DATA_PREFIX \
+        --capabilities CAPABILITY_NAMED_IAM \
+        --region $REGION
+    
+    wait_for_stack $STACK_NAME "create"
+fi
+
+# Deploy table schema stack if requested
+if [ "$DEPLOY_TABLES" = true ]; then
+    print_message $YELLOW "📦 Deploying table schema stack..."
+    
+    if stack_exists $TABLE_STACK_NAME; then
+        print_message $YELLOW "Stack $TABLE_STACK_NAME already exists. Updating..."
+        aws cloudformation update-stack \
+            --stack-name $TABLE_STACK_NAME \
+            --template-body file://glue-table-schema.yaml \
+            --parameters \
+                ParameterKey=S3BucketName,ParameterValue=$S3_BUCKET \
+                ParameterKey=DataPrefix,ParameterValue=$DATA_PREFIX \
+            --region $REGION
+        
+        wait_for_stack $TABLE_STACK_NAME "update"
+    else
+        print_message $YELLOW "Creating new stack $TABLE_STACK_NAME..."
+        aws cloudformation create-stack \
+            --stack-name $TABLE_STACK_NAME \
+            --template-body file://glue-table-schema.yaml \
+            --parameters \
+                ParameterKey=S3BucketName,ParameterValue=$S3_BUCKET \
+                ParameterKey=DataPrefix,ParameterValue=$DATA_PREFIX \
+            --region $REGION
+        
+        wait_for_stack $TABLE_STACK_NAME "create"
+    fi
+fi
+
+# Get stack outputs
+print_message $YELLOW "📋 Getting stack outputs..."
+CRAWLER_NAME=$(aws cloudformation describe-stacks \
+    --stack-name $STACK_NAME \
+    --query 'Stacks[0].Outputs[?OutputKey==`GlueCrawlerName`].OutputValue' \
+    --output text \
+    --region $REGION)
+
+DATABASE_NAME=$(aws cloudformation describe-stacks \
+    --stack-name $STACK_NAME \
+    --query 'Stacks[0].Outputs[?OutputKey==`GlueDatabaseName`].OutputValue' \
+    --output text \
+    --region $REGION)
+
+WORKGROUP_NAME=$(aws cloudformation describe-stacks \
+    --stack-name $STACK_NAME \
+    --query 'Stacks[0].Outputs[?OutputKey==`AthenaWorkGroupName`].OutputValue' \
+    --output text \
+    --region $REGION)
+
+# Run the crawler
+print_message $YELLOW "🕷️  Starting Glue Crawler..."
+aws glue start-crawler --name $CRAWLER_NAME --region $REGION
+
+print_message $GREEN "✅ Deployment completed successfully!"
+echo ""
+print_message $GREEN "📊 Next Steps:"
+echo "1. Wait for the crawler to complete (check status with: aws glue get-crawler --name $CRAWLER_NAME)"
+echo "2. Open Athena console and select workgroup: $WORKGROUP_NAME"
+echo "3. Select database: $DATABASE_NAME"
+echo "4. Run queries from the athena-queries/ directory"
+echo ""
+print_message $YELLOW "💡 Example query:"
+echo "aws athena start-query-execution \\"
+echo "  --query-string \"SELECT COUNT(*) FROM ${DATABASE_NAME}.tokyo_properties\" \\"
+echo "  --work-group $WORKGROUP_NAME \\"
+echo "  --query-execution-context Database=$DATABASE_NAME"

--- a/aws-infrastructure/glue-athena-stack.yaml
+++ b/aws-infrastructure/glue-athena-stack.yaml
@@ -1,0 +1,284 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'AWS Glue and Athena infrastructure for real estate data analysis'
+
+Parameters:
+  S3BucketName:
+    Type: String
+    Description: S3 bucket name containing the real estate data
+    Default: real-estate-data
+  
+  DataPrefix:
+    Type: String
+    Description: S3 prefix for cleaned data
+    Default: cleaned/tokyo/
+  
+  GlueDatabaseName:
+    Type: String
+    Description: Name for the Glue database
+    Default: real_estate_db
+  
+  CrawlerName:
+    Type: String
+    Description: Name for the Glue Crawler
+    Default: real-estate-crawler
+
+Resources:
+  # Glue Database
+  GlueDatabase:
+    Type: AWS::Glue::Database
+    Properties:
+      CatalogId: !Ref AWS::AccountId
+      DatabaseInput:
+        Name: !Ref GlueDatabaseName
+        Description: Database for real estate property data from Japanese portals
+
+  # IAM Role for Glue Crawler
+  GlueCrawlerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${CrawlerName}-role'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - glue.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
+      Policies:
+        - PolicyName: S3AccessPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:ListBucket
+                Resource:
+                  - !Sub 'arn:aws:s3:::${S3BucketName}'
+                  - !Sub 'arn:aws:s3:::${S3BucketName}/*'
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: '*'
+
+  # Glue Crawler
+  GlueCrawler:
+    Type: AWS::Glue::Crawler
+    Properties:
+      Name: !Ref CrawlerName
+      Role: !GetAtt GlueCrawlerRole.Arn
+      DatabaseName: !Ref GlueDatabase
+      Description: Crawler for real estate data in S3
+      Targets:
+        S3Targets:
+          - Path: !Sub 's3://${S3BucketName}/${DataPrefix}'
+      SchemaChangePolicy:
+        UpdateBehavior: UPDATE_IN_DATABASE
+        DeleteBehavior: LOG
+      Configuration: |
+        {
+          "Version": 1.0,
+          "CrawlerOutput": {
+            "Partitions": {
+              "AddOrUpdateBehavior": "InheritFromTable"
+            }
+          }
+        }
+      Schedule:
+        # Run daily at 2 AM JST (5 PM UTC)
+        ScheduleExpression: 'cron(0 17 * * ? *)'
+
+  # Athena Workgroup for cost tracking and query management
+  AthenaWorkGroup:
+    Type: AWS::Athena::WorkGroup
+    Properties:
+      Name: real-estate-analysis
+      Description: Workgroup for real estate data analysis
+      WorkGroupConfiguration:
+        ResultConfigurationUpdates:
+          OutputLocation: !Sub 's3://${S3BucketName}/athena-results/'
+        EnforceWorkGroupConfiguration: true
+        PublishCloudWatchMetricsEnabled: true
+        EngineVersion:
+          SelectedEngineVersion: 'Athena engine version 3'
+
+  # Athena Named Queries for common analysis patterns
+  AvgRentByWardQuery:
+    Type: AWS::Athena::NamedQuery
+    Properties:
+      Name: Average Rent by Ward
+      Description: Calculate average rent by Tokyo ward
+      Database: !Ref GlueDatabaseName
+      QueryString: !Sub |
+        SELECT 
+          city as ward,
+          property_type,
+          COUNT(*) as property_count,
+          AVG(rent) as avg_rent,
+          MIN(rent) as min_rent,
+          MAX(rent) as max_rent,
+          PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY rent) as median_rent
+        FROM ${GlueDatabaseName}.tokyo_properties
+        WHERE rent > 0
+        GROUP BY city, property_type
+        ORDER BY avg_rent DESC;
+      WorkGroup: !Ref AthenaWorkGroup
+
+  StationDistanceAnalysisQuery:
+    Type: AWS::Athena::NamedQuery
+    Properties:
+      Name: Property Analysis by Station Distance
+      Description: Analyze properties by walking distance to station
+      Database: !Ref GlueDatabaseName
+      QueryString: !Sub |
+        SELECT 
+          CASE 
+            WHEN station_distance <= 5 THEN '0-5 minutes'
+            WHEN station_distance <= 10 THEN '6-10 minutes'
+            WHEN station_distance <= 15 THEN '11-15 minutes'
+            ELSE '15+ minutes'
+          END as distance_range,
+          COUNT(*) as property_count,
+          AVG(area) as avg_area,
+          AVG(rent) as avg_rent,
+          AVG(rent / area) as avg_rent_per_sqm
+        FROM ${GlueDatabaseName}.tokyo_properties
+        WHERE station_distance IS NOT NULL
+        GROUP BY 
+          CASE 
+            WHEN station_distance <= 5 THEN '0-5 minutes'
+            WHEN station_distance <= 10 THEN '6-10 minutes'
+            WHEN station_distance <= 15 THEN '11-15 minutes'
+            ELSE '15+ minutes'
+          END
+        ORDER BY 
+          CASE distance_range
+            WHEN '0-5 minutes' THEN 1
+            WHEN '6-10 minutes' THEN 2
+            WHEN '11-15 minutes' THEN 3
+            ELSE 4
+          END;
+      WorkGroup: !Ref AthenaWorkGroup
+
+  BuildingAgeDistributionQuery:
+    Type: AWS::Athena::NamedQuery
+    Properties:
+      Name: Building Age Distribution
+      Description: Distribution of properties by building age
+      Database: !Ref GlueDatabaseName
+      QueryString: !Sub |
+        WITH age_buckets AS (
+          SELECT 
+            property_id,
+            rent,
+            area,
+            CASE 
+              WHEN building_age <= 5 THEN '0-5 years'
+              WHEN building_age <= 10 THEN '6-10 years'
+              WHEN building_age <= 20 THEN '11-20 years'
+              WHEN building_age <= 30 THEN '21-30 years'
+              ELSE '30+ years'
+            END as age_range
+          FROM ${GlueDatabaseName}.tokyo_properties
+          WHERE building_age IS NOT NULL
+        )
+        SELECT 
+          age_range,
+          COUNT(*) as property_count,
+          AVG(rent) as avg_rent,
+          AVG(area) as avg_area,
+          AVG(rent / area) as avg_rent_per_sqm
+        FROM age_buckets
+        GROUP BY age_range
+        ORDER BY 
+          CASE age_range
+            WHEN '0-5 years' THEN 1
+            WHEN '6-10 years' THEN 2
+            WHEN '11-20 years' THEN 3
+            WHEN '21-30 years' THEN 4
+            ELSE 5
+          END;
+      WorkGroup: !Ref AthenaWorkGroup
+
+  FloorPlanAnalysisQuery:
+    Type: AWS::Athena::NamedQuery
+    Properties:
+      Name: Floor Plan Analysis
+      Description: Analyze properties by floor plan type
+      Database: !Ref GlueDatabaseName
+      QueryString: !Sub |
+        SELECT 
+          floor_plan,
+          COUNT(*) as property_count,
+          AVG(rent) as avg_rent,
+          AVG(area) as avg_area,
+          MIN(rent) as min_rent,
+          MAX(rent) as max_rent,
+          PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY rent) as median_rent
+        FROM ${GlueDatabaseName}.tokyo_properties
+        WHERE floor_plan IS NOT NULL
+        GROUP BY floor_plan
+        ORDER BY property_count DESC
+        LIMIT 20;
+      WorkGroup: !Ref AthenaWorkGroup
+
+  PricePerSqmByLocationQuery:
+    Type: AWS::Athena::NamedQuery
+    Properties:
+      Name: Price per Square Meter by Location
+      Description: Calculate average rent per square meter by ward
+      Database: !Ref GlueDatabaseName
+      QueryString: !Sub |
+        SELECT 
+          city as ward,
+          COUNT(*) as property_count,
+          AVG(rent / area) as avg_rent_per_sqm,
+          MIN(rent / area) as min_rent_per_sqm,
+          MAX(rent / area) as max_rent_per_sqm,
+          PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY rent / area) as median_rent_per_sqm
+        FROM ${GlueDatabaseName}.tokyo_properties
+        WHERE rent > 0 AND area > 0
+        GROUP BY city
+        HAVING COUNT(*) >= 10
+        ORDER BY avg_rent_per_sqm DESC;
+      WorkGroup: !Ref AthenaWorkGroup
+
+Outputs:
+  GlueDatabaseName:
+    Description: Name of the Glue database
+    Value: !Ref GlueDatabase
+    Export:
+      Name: !Sub '${AWS::StackName}-GlueDatabase'
+
+  GlueCrawlerName:
+    Description: Name of the Glue Crawler
+    Value: !Ref GlueCrawler
+    Export:
+      Name: !Sub '${AWS::StackName}-GlueCrawler'
+
+  AthenaWorkGroupName:
+    Description: Name of the Athena WorkGroup
+    Value: !Ref AthenaWorkGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-AthenaWorkGroup'
+
+  GlueCrawlerRoleArn:
+    Description: ARN of the Glue Crawler IAM role
+    Value: !GetAtt GlueCrawlerRole.Arn
+    Export:
+      Name: !Sub '${AWS::StackName}-GlueCrawlerRoleArn'
+
+  SampleQueryInstructions:
+    Description: Instructions for running sample queries
+    Value: !Sub |
+      To run the sample queries:
+      1. Open the Athena console
+      2. Select workgroup: ${AthenaWorkGroup}
+      3. Select database: ${GlueDatabaseName}
+      4. Navigate to "Saved queries" to find the pre-defined analysis queries

--- a/aws-infrastructure/glue-table-schema.yaml
+++ b/aws-infrastructure/glue-table-schema.yaml
@@ -1,0 +1,268 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Explicit Glue table schema definition for real estate data'
+
+Parameters:
+  GlueDatabaseName:
+    Type: String
+    Description: Name of the Glue database
+    Default: real_estate_db
+  
+  S3BucketName:
+    Type: String
+    Description: S3 bucket name containing the real estate data
+    Default: real-estate-data
+  
+  DataPrefix:
+    Type: String
+    Description: S3 prefix for cleaned data
+    Default: cleaned/tokyo/
+
+Resources:
+  # Explicit table definition for real estate properties
+  RealEstateTable:
+    Type: AWS::Glue::Table
+    Properties:
+      CatalogId: !Ref AWS::AccountId
+      DatabaseName: !Ref GlueDatabaseName
+      TableInput:
+        Name: tokyo_properties
+        Description: Tokyo real estate property listings
+        TableType: EXTERNAL_TABLE
+        Parameters:
+          classification: parquet
+          compressionType: snappy
+          typeOfData: file
+        StorageDescriptor:
+          Columns:
+            # Basic identification
+            - Name: property_id
+              Type: string
+              Comment: Unique property identifier
+            - Name: site_name
+              Type: string
+              Comment: Source website name
+            - Name: url
+              Type: string
+              Comment: Property listing URL
+            
+            # Property details
+            - Name: title
+              Type: string
+              Comment: Property listing title
+            - Name: property_type
+              Type: string
+              Comment: Type of property (マンション, アパート, 一戸建て)
+            
+            # Location fields
+            - Name: prefecture
+              Type: string
+              Comment: Prefecture (都道府県)
+            - Name: city
+              Type: string
+              Comment: City/Ward (市区町村)
+            - Name: district
+              Type: string
+              Comment: District/Area (地区)
+            - Name: address
+              Type: string
+              Comment: Full address
+            - Name: latitude
+              Type: double
+              Comment: Latitude coordinate
+            - Name: longitude
+              Type: double
+              Comment: Longitude coordinate
+            
+            # Price information (mapped from issue requirements)
+            - Name: rent
+              Type: int
+              Comment: Monthly rent in JPY (mapped to price)
+            - Name: management_fee
+              Type: int
+              Comment: Management fee in JPY
+            - Name: deposit
+              Type: int
+              Comment: Deposit amount in JPY
+            - Name: key_money
+              Type: int
+              Comment: Key money in JPY
+            
+            # Property specifications
+            - Name: floor_plan
+              Type: string
+              Comment: Floor plan layout (1K, 1LDK, etc.) - mapped to layout
+            - Name: area
+              Type: double
+              Comment: Floor area in square meters
+            - Name: floor_number
+              Type: int
+              Comment: Floor number
+            - Name: total_floors
+              Type: int
+              Comment: Total floors in building
+            - Name: building_age
+              Type: int
+              Comment: Building age in years
+            - Name: construction_year
+              Type: int
+              Comment: Year of construction (mapped to year_built)
+            
+            # Transportation
+            - Name: nearest_station
+              Type: string
+              Comment: Nearest station name
+            - Name: station_distance
+              Type: int
+              Comment: Walking distance to station in minutes (mapped to walk_time_to_station)
+            - Name: train_lines
+              Type: array<string>
+              Comment: Available train lines
+            
+            # Additional features
+            - Name: features
+              Type: array<string>
+              Comment: Property features and amenities
+            
+            # Metadata
+            - Name: scraped_at
+              Type: timestamp
+              Comment: Timestamp when data was scraped (mapped to date)
+            - Name: updated_at
+              Type: timestamp
+              Comment: Last update timestamp
+            
+          Location: !Sub 's3://${S3BucketName}/${DataPrefix}'
+          InputFormat: org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat
+          OutputFormat: org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat
+          SerdeInfo:
+            SerializationLibrary: org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe
+            Parameters:
+              serialization.format: '1'
+          Compressed: true
+          StoredAsSubDirectories: false
+        PartitionKeys:
+          - Name: year
+            Type: string
+            Comment: Year partition (YYYY)
+          - Name: month
+            Type: string
+            Comment: Month partition (MM)
+          - Name: day
+            Type: string
+            Comment: Day partition (DD)
+
+  # Alternative CSV table if data is stored as CSV
+  RealEstateTableCSV:
+    Type: AWS::Glue::Table
+    Properties:
+      CatalogId: !Ref AWS::AccountId
+      DatabaseName: !Ref GlueDatabaseName
+      TableInput:
+        Name: tokyo_properties_csv
+        Description: Tokyo real estate property listings (CSV format)
+        TableType: EXTERNAL_TABLE
+        Parameters:
+          classification: csv
+          typeOfData: file
+          skip.header.line.count: '1'
+        StorageDescriptor:
+          Columns:
+            # Same column definitions as above
+            - Name: property_id
+              Type: string
+            - Name: site_name
+              Type: string
+            - Name: url
+              Type: string
+            - Name: title
+              Type: string
+            - Name: property_type
+              Type: string
+            - Name: prefecture
+              Type: string
+            - Name: city
+              Type: string
+            - Name: district
+              Type: string
+            - Name: address
+              Type: string
+            - Name: latitude
+              Type: double
+            - Name: longitude
+              Type: double
+            - Name: rent
+              Type: int
+            - Name: management_fee
+              Type: int
+            - Name: deposit
+              Type: int
+            - Name: key_money
+              Type: int
+            - Name: floor_plan
+              Type: string
+            - Name: area
+              Type: double
+            - Name: floor_number
+              Type: int
+            - Name: total_floors
+              Type: int
+            - Name: building_age
+              Type: int
+            - Name: construction_year
+              Type: int
+            - Name: nearest_station
+              Type: string
+            - Name: station_distance
+              Type: int
+            - Name: train_lines
+              Type: string
+            - Name: features
+              Type: string
+            - Name: scraped_at
+              Type: timestamp
+            - Name: updated_at
+              Type: timestamp
+          Location: !Sub 's3://${S3BucketName}/${DataPrefix}csv/'
+          InputFormat: org.apache.hadoop.mapred.TextInputFormat
+          OutputFormat: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+          SerdeInfo:
+            SerializationLibrary: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Parameters:
+              field.delim: ','
+              serialization.format: ','
+          Compressed: false
+          StoredAsSubDirectories: false
+        PartitionKeys:
+          - Name: year
+            Type: string
+          - Name: month
+            Type: string
+          - Name: day
+            Type: string
+
+Outputs:
+  ParquetTableName:
+    Description: Name of the Parquet format table
+    Value: !Ref RealEstateTable
+    Export:
+      Name: !Sub '${AWS::StackName}-ParquetTable'
+
+  CSVTableName:
+    Description: Name of the CSV format table
+    Value: !Ref RealEstateTableCSV
+    Export:
+      Name: !Sub '${AWS::StackName}-CSVTable'
+
+  FieldMapping:
+    Description: Mapping between issue requirements and actual field names
+    Value: |
+      Field Mapping Reference:
+      - price → rent (int)
+      - area → area (float)
+      - layout → floor_plan (string)
+      - year_built → construction_year (int)
+      - walk_time_to_station → station_distance (int)
+      - latitude → latitude (float)
+      - longitude → longitude (float)
+      - date → scraped_at (timestamp)
+      - address → address (string)


### PR DESCRIPTION
This PR implements the AWS Glue and Athena infrastructure for analyzing real estate data stored in S3.

## Changes

- Added CloudFormation templates for Glue Database, Crawler, and Athena Workgroup
- Created explicit table schema definitions for both Parquet and CSV formats
- Added 8 comprehensive Athena SQL queries for various analysis patterns
- Included deployment and cleanup scripts for easy infrastructure management
- Added detailed documentation with integration guides for QuickSight, Redshift, and SageMaker

Closes #8

Generated with [Claude Code](https://claude.ai/code)