### PR TITLE
fix: SUUMO scraping 404 error by using slug-based URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ mypy src/
 2. **Rate Limiting**: Built-in rate limiting prevents overwhelming target servers
 3. **Legal Compliance**: Ensure compliance with website terms of service
 4. **Data Privacy**: Handle scraped data responsibly
+5. **SUUMO Area Codes**: SUUMO uses slug-based URLs (e.g., `sc_shibuya`) instead of standard area codes. The system automatically converts area codes to SUUMO slugs for Tokyo 23 wards. Direct slug input is also supported.
 
 ## 🗺️ Roadmap / ロードマップ
 

--- a/src/config/area_mapping.py
+++ b/src/config/area_mapping.py
@@ -1,0 +1,61 @@
+"""
+Area code to SUUMO slug mapping for Tokyo 23 wards.
+"""
+
+# Mapping from standard area codes to SUUMO URL slugs
+AREA_CODE_TO_SUUMO_SLUG = {
+    "13101": "sc_chiyoda",     # 千代田区
+    "13102": "sc_chuo",        # 中央区
+    "13103": "sc_minato",      # 港区
+    "13104": "sc_shinjuku",    # 新宿区
+    "13105": "sc_bunkyo",      # 文京区
+    "13106": "sc_taito",       # 台東区
+    "13107": "sc_sumida",      # 墨田区
+    "13108": "sc_koto",        # 江東区
+    "13109": "sc_shinagawa",   # 品川区
+    "13110": "sc_meguro",      # 目黒区
+    "13111": "sc_ota",         # 大田区
+    "13112": "sc_setagaya",    # 世田谷区
+    "13113": "sc_shibuya",     # 渋谷区
+    "13114": "sc_nakano",      # 中野区
+    "13115": "sc_suginami",    # 杉並区
+    "13116": "sc_toshima",     # 豊島区
+    "13117": "sc_kita",        # 北区
+    "13118": "sc_arakawa",     # 荒川区
+    "13119": "sc_itabashi",    # 板橋区
+    "13120": "sc_nerima",      # 練馬区
+    "13121": "sc_adachi",      # 足立区
+    "13122": "sc_katsushika",  # 葛飾区
+    "13123": "sc_edogawa",     # 江戸川区
+}
+
+
+def get_suumo_slug(area_code: str) -> str:
+    """
+    Get SUUMO slug for a given area code.
+    
+    Args:
+        area_code: Standard area code (e.g., "13113")
+        
+    Returns:
+        SUUMO slug (e.g., "sc_shibuya")
+        
+    Raises:
+        KeyError: If area code is not found in mapping
+    """
+    if area_code not in AREA_CODE_TO_SUUMO_SLUG:
+        raise KeyError(f"Area code '{area_code}' not found in SUUMO mapping")
+    return AREA_CODE_TO_SUUMO_SLUG[area_code]
+
+
+def is_suumo_slug(value: str) -> bool:
+    """
+    Check if a value is already a SUUMO slug.
+    
+    Args:
+        value: String to check
+        
+    Returns:
+        True if value is a SUUMO slug, False otherwise
+    """
+    return value.startswith("sc_") and value in AREA_CODE_TO_SUUMO_SLUG.values()

--- a/src/scrapers/suumo.py
+++ b/src/scrapers/suumo.py
@@ -11,6 +11,7 @@ from loguru import logger
 from .base import BaseScraper
 from ..models.property import Property, PropertySearchResult
 from ..utils.text_parser import JapaneseTextParser
+from ..config.area_mapping import get_suumo_slug, is_suumo_slug
 
 
 class SuumoScraper(BaseScraper):
@@ -33,8 +34,22 @@ class SuumoScraper(BaseScraper):
         # Note: This is a placeholder implementation
         # Actual URLs and parsing logic would need to be implemented based on SUUMO's structure
         
-        # Construct search URL (this is an example - actual URL structure may differ)
-        search_url = f"{self.base_url}/chintai/tokyo/city/{area['code']}/"
+        # Convert area code to SUUMO slug
+        try:
+            area_identifier = area['code']
+            if is_suumo_slug(area_identifier):
+                # Already a slug, use as-is
+                slug = area_identifier
+            else:
+                # Convert area code to slug
+                slug = get_suumo_slug(area_identifier)
+                logger.debug(f"Converted area code {area_identifier} to SUUMO slug {slug}")
+        except KeyError as e:
+            logger.error(f"Area code '{area['code']}' not supported by SUUMO: {str(e)}")
+            return None
+        
+        # Construct search URL using slug format
+        search_url = f"{self.base_url}/chintai/tokyo/{slug}/"
         if page > 1:
             search_url += f"?page={page}"
             


### PR DESCRIPTION
Fixes #16

## Summary

Fixed SUUMO scraping that was failing with 404 errors due to incorrect URL construction.

## Changes

- Added `src/config/area_mapping.py` with Tokyo 23 ward area code to SUUMO slug mappings
- Updated SUUMO scraper to convert area codes to slugs (e.g., 13113 → sc_shibuya)
- Added error handling for unsupported area codes
- Updated README with note about SUUMO area code limitations

## Testing

The scraper now correctly constructs URLs like `https://suumo.jp/chintai/tokyo/sc_shibuya/` instead of the invalid `https://suumo.jp/chintai/tokyo/city/13113/`.

Generated with [Claude Code](https://claude.ai/code)